### PR TITLE
Add missing function trim_all_columns(df)

### DIFF
--- a/interface/radar_factory.py
+++ b/interface/radar_factory.py
@@ -15,6 +15,13 @@ from matplotlib.transforms import Affine2D
 import numpy as np
 
 
+def trim_all_columns(df):
+    """
+    Trim whitespace from ends of each value across all series in dataframe
+    """
+    trim_strings = lambda x: x.strip() if type(x) is str else x
+    return df.applymap(trim_strings)
+
 def radar_factory(num_vars, frame='circle'):
     """Create a radar chart with `num_vars` axes.
 


### PR DESCRIPTION
Hello, @e-maud 

I am researching interfaces of digitized newspapers in the Portuguese language as part of my postdoctoral research at the DH_Lab of the Universidade Nova de Lisboa.

This is an extension of previous research on the Hemeroteca Digital Brasileira (Digital Newspaper Library of Brazil) at the National Library of Brazil.

Your paper '[Historic Newspaper User Interfaces: A Review](http://infoscience.epfl.ch/record/270246) (2019)' has served as a methodological foundation for the analysis of the interfaces of digital newspaper libraries in Brazil and Portugal. I would like to express that it is an incredible work and an inspiration for my reflections, as well as the entire work of the _impresso project_.

While attempting to execute the notebook to analyze the TSV, I noticed that in the current version, the function `trim_all_columns(df)` is missing both in the `.ipynb` file and in the `interface/radar_factory.py` file.

It was present in an earlier version of the `.ipynb` file, which can be seen here: [link to GitHub](https://github.com/impresso/impresso-interface-review/blob/341ee1dad31d5d88af43e07f39015124196b22e7/notebooks/Interface_Reviews.ipynb)

The function is as follows:

```
def trim_all_columns(df):
    """
    Trim whitespace from ends of each value across all series in dataframe
    """
    trim_strings = lambda x: x.strip() if type(x) is str else x
    return df.applymap(trim_strings)
```

I have included the function in the file `interface/radar_factory.py`, as in the `.ipynb` file, it is being imported from `interface.radar_factory`.
